### PR TITLE
worked on the PHP and styling the footer-enroll

### DIFF
--- a/site/web/app/themes/sage/assets/styles/components/footer/footer-enroll.sass
+++ b/site/web/app/themes/sage/assets/styles/components/footer/footer-enroll.sass
@@ -49,5 +49,5 @@ $primary-color: #b42d00
             width: 82%
             
         a
-            height: 60px
-            width: 60%
+            height: 40px
+            width: 30%

--- a/site/web/app/themes/sage/templates/components/footer/footer-enroll.php
+++ b/site/web/app/themes/sage/templates/components/footer/footer-enroll.php
@@ -5,9 +5,9 @@
         </h3>
     <?php endif; ?>
 
-    <?php if (get_field('enroll-text')) : ?>
+    <?php if (get_field('enroll_text')) : ?>
         <p>
-            <?php the_field('enroll-text'); ?>
+            <?php the_field('enroll_text'); ?>
         </p>
     <?php endif; ?>
 


### PR DESCRIPTION
I used the PHP format we had and styled within the Sass file path for the footer-enroll portion. 

<img width="1241" alt="screen shot 2017-10-12 at 2 17 03 pm" src="https://user-images.githubusercontent.com/24723548/31512529-4ca8f12c-af59-11e7-9846-e3e8acdd3bf9.png">

A screenshot of 768px. 
<img width="747" alt="screen shot 2017-10-12 at 2 17 26 pm" src="https://user-images.githubusercontent.com/24723548/31512531-4fce1ce2-af59-11e7-9b33-75ccd571b0d9.png">

A screenshot of 480px. 
<img width="478" alt="screen shot 2017-10-12 at 2 18 30 pm" src="https://user-images.githubusercontent.com/24723548/31512533-51425e94-af59-11e7-9f8f-d306bc8ac60a.png">
